### PR TITLE
Switch decode_token to async since it does a network call

### DIFF
--- a/src/fastapi_auth0/auth.py
+++ b/src/fastapi_auth0/auth.py
@@ -175,7 +175,7 @@ class Auth0:
                     logger.warning(msg)
                     return None
             try:
-                signing_key = await run_in_threadpool(self.jwks_client.get_signing_key_from_jwt, self, token)
+                signing_key = await run_in_threadpool(self.jwks_client.get_signing_key_from_jwt, token)
                 options = options or {}
                 leeway = options.pop("leeway", 0)
                 payload = jwt.decode(


### PR DESCRIPTION
decode_token can do a network call to Auth0 to get public keys, which will be a blocking call. Make the function async and run it in the FastAPI threadpool